### PR TITLE
Change minimap aspect ratio to 4:3 (fix stretched y-axis)

### DIFF
--- a/MinimapGUI.cs
+++ b/MinimapGUI.cs
@@ -339,7 +339,7 @@ namespace LethalCompanyMinimap.Component
 
                         if (LeftClickButton(new Rect(guiCenterX, guiYpos + 440, ITEMWIDTH, 30), "Reset to Default Size"))
                         {
-                            minimapSize = 200;
+                            minimapSize = 150;
                         }
                         if (LeftClickButton(new Rect(guiCenterX, guiYpos + 480, ITEMWIDTH, 30), "Reset to Default Position"))
                         {

--- a/Patches/PlayerControllerBPatch.cs
+++ b/Patches/PlayerControllerBPatch.cs
@@ -15,6 +15,7 @@ namespace LethalCompanyMinimap.Patches
     internal class PlayerControllerBPatch
     {
         private const int padding = -5;
+        private const float aspectRatio = (4f / 3f); // Aspect ratio of the ship monitor (4:3)
         private static GameObject minimapObj;
         private static RawImage minimap;
         private static RectTransform tooltips;
@@ -42,7 +43,8 @@ namespace LethalCompanyMinimap.Patches
             }
 
             // Get the Minimap size from the settings
-            int size = MinimapMod.minimapGUI.minimapSize;
+            int height = MinimapMod.minimapGUI.minimapSize;
+            int width = (int)(height * aspectRatio);
 
             // Check if we have a Minimap yet
             if (minimap == null || minimapObj == null)
@@ -55,7 +57,7 @@ namespace LethalCompanyMinimap.Patches
                 minimap.rectTransform.anchorMin = new Vector2(1, 1);
                 minimap.rectTransform.anchorMax = new Vector2(1, 1);
                 minimap.rectTransform.pivot = new Vector2(1f, 1f);
-                minimap.rectTransform.sizeDelta = new Vector2(size, size);
+                minimap.rectTransform.sizeDelta = new Vector2(width, height);
                 minimap.rectTransform.anchoredPosition = new Vector2(
                     MinimapMod.minimapGUI.minimapXPos, MinimapMod.minimapGUI.minimapYPos + padding
                 );
@@ -89,7 +91,7 @@ namespace LethalCompanyMinimap.Patches
             {
                 tooltipsOriginalPos = tooltips.anchoredPosition;
             }
-            tooltips.anchoredPosition -= new Vector2(0, size);
+            tooltips.anchoredPosition -= new Vector2(0, height);
 
             // Request Minimap Version and sharing our own Minimap Version
             HUDManagerPatch.SendMinimapBroadcast("VersionReq");
@@ -125,9 +127,10 @@ namespace LethalCompanyMinimap.Patches
                 // Resize Minimap
                 if (MinimapMod.minimapGUI.minimapSize != minimap.rectTransform.sizeDelta.y)
                 {
-                    int size = MinimapMod.minimapGUI.minimapSize;
-                    minimap.rectTransform.sizeDelta = new Vector2(size, size);
-                    tooltips.anchoredPosition = tooltipsOriginalPos - new Vector2(0, size);
+                    int height = MinimapMod.minimapGUI.minimapSize;
+                    int width = (int)(height * aspectRatio);
+                    minimap.rectTransform.sizeDelta = new Vector2(width, height);
+                    tooltips.anchoredPosition = tooltipsOriginalPos - new Vector2(0, height);
                 }
                 // Move Minimap
                 if (MinimapMod.minimapGUI.minimapXPos != minimap.rectTransform.anchoredPosition.x

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -26,7 +26,7 @@ namespace LethalCompanyMinimap
         public static MouseAndKeyboard defaultToggleMinimapKey = MouseAndKeyboard.F2;
         public static MouseAndKeyboard defaultToggleOverrideKey = MouseAndKeyboard.F3;
         public static MouseAndKeyboard defaultSwitchTargetKey = MouseAndKeyboard.F4;
-        public const int defaultMinimapSize = 200;
+        public const int defaultMinimapSize = 150;
         public const float defaultXoffset = 0f;
         public const float defaultYoffset = 0f;
         public const float defaultMapZoom = 19.7f;


### PR DESCRIPTION
## The issue:
The minimap appears stretched on the y-axis. This happens because the content of the minimap is designed for the aspect ratio of the monitor on the ship, which appears to be 4:3

![before](https://github.com/tyzeron/LethalCompanyMinimap/assets/20732219/f0e8a5da-7b80-4d08-85dc-ddce796aa1e9)

## Proposed solution:
* Change the minimap to also be 4:3
* Reduce default size to 150 (which should be equivalent to the previous 200, except it's not stretched)

![after](https://github.com/tyzeron/LethalCompanyMinimap/assets/20732219/c6242fd5-5ffe-48c8-9513-c48c07b4b61a)


## Alternative solution:
If you want the minimap to stay 1:1 you could probably change the scaling of the minimap content somehow. I tried a little bit but couldn't figure it out. I have no experience with Unity and game/mod development.